### PR TITLE
Add SEO helpers, metadata/JSON-LD and enrich resume & tool pages

### DIFF
--- a/src/app/[lang]/resume/page.tsx
+++ b/src/app/[lang]/resume/page.tsx
@@ -12,6 +12,10 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import { PrintButton } from '@/components/print-button';
 import Image from 'next/image';
 import htmlParse from 'html-react-parser';
+import type { Metadata } from 'next';
+import { buildLanguageAlternates, buildUrl } from '@/shared/helpers/seo';
+
+const resumeSkills = ['JavaScript', 'TypeScript', 'Node.js', 'React', 'NestJS'];
 
 export async function generateStaticParams() {
   return langList.map((lang) => ({
@@ -19,10 +23,71 @@ export async function generateStaticParams() {
   }));
 }
 
+export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }): Promise<Metadata> {
+  const { lang } = await params;
+  const t = getI18n(lang);
+  const resume = await api.resume.get(lang);
+  const title = `${t.main.name} — ${resume.position} Resume`;
+  const description = resume.summary?.text
+    ?.map((text) =>
+      text.replace(/<[^>]+>/g, '').replace('{experienceInYears}', (new Date().getFullYear() - 2008).toString()),
+    )
+    .join(' ')
+    .slice(0, 220);
+  const url = buildUrl('/resume', lang);
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: url,
+      languages: buildLanguageAlternates('/resume'),
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: 'Aleksey Svetlitskiy',
+      locale: lang,
+      type: 'profile',
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
+  };
+}
+
 export default async function ResumePage({ params }: { params: Promise<{ lang: string }> }) {
   const { lang } = await params;
   const t = getI18n(lang);
   const resume = await api.resume.get(lang);
+  const url = buildUrl('/resume', lang);
+  const description = resume.summary?.text
+    ?.map((text) =>
+      text.replace(/<[^>]+>/g, '').replace('{experienceInYears}', (new Date().getFullYear() - 2008).toString()),
+    )
+    .join(' ');
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ProfilePage',
+    name: `${t.main.name} — ${resume.position}`,
+    url,
+    inLanguage: lang,
+    mainEntity: {
+      '@type': 'Person',
+      name: t.main.name,
+      alternateName: resume.name,
+      jobTitle: resume.position,
+      description,
+      email: contacts.email,
+      image: `${contacts.github.avatar}?s=200`,
+      url,
+      sameAs: [contacts.linkedin, contacts.github.page, contacts.telegram.link],
+      knowsAbout: resumeSkills,
+    },
+  };
 
   return (
     <section
@@ -30,6 +95,8 @@ export default async function ResumePage({ params }: { params: Promise<{ lang: s
       itemType="https://schema.org/Person"
       className="xl:max-w-[1280px] mx-auto p-4 gap-6 flex flex-col w-full"
     >
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
       <header
         className="pb-16 md:pb-8 flex flex-col md:flex-row-reverse md:justify-between
       print:pb-8 flex flex-col print:flex-row-reverse print:justify-between
@@ -68,14 +135,14 @@ export default async function ResumePage({ params }: { params: Promise<{ lang: s
         <PrintButton />
       </aside>
 
-      <section className="hidden">
+      <section>
         <Typography variant="h2">Skills</Typography>
-        <ul>
-          <li itemProp="skills">JavaScript</li>
-          <li itemProp="skills">TypeScript</li>
-          <li itemProp="skills">Node.js</li>
-          <li itemProp="skills">React</li>
-          <li itemProp="skills">NestJS</li>
+        <ul className="flex flex-wrap gap-2">
+          {resumeSkills.map((skill) => (
+            <li itemProp="skills" key={skill} className="border border-current rounded px-2 py-1">
+              {skill}
+            </li>
+          ))}
         </ul>
       </section>
 

--- a/src/app/[lang]/tool/hex-to-rgb-converter/page.tsx
+++ b/src/app/[lang]/tool/hex-to-rgb-converter/page.tsx
@@ -2,9 +2,9 @@ import React, { JSX } from 'react';
 import { getI18n } from '@/i18n/i18n';
 import { Typography } from '@mui/material';
 
-import { projectUrl } from '@/conf';
 import { I18nLocaleInterface } from '@/i18n/i18n.interface';
 import HexToRgbConverter from '@/components/tools/hex-to-rgb-converter';
+import { buildLanguageAlternates, buildUrl } from '@/shared/helpers/seo';
 
 export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }) {
   const { lang } = await params;
@@ -12,13 +12,14 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
 
   const title = t.tools.hexToRgbConverter.title;
   const description = t.tools.hexToRgbConverter.description;
-  const url = `${projectUrl}/${lang}/tool/rem-to-px-converter/`;
+  const url = buildUrl('/tool/hex-to-rgb-converter', lang);
 
   return {
     title,
     description,
     alternates: {
       canonical: url,
+      languages: buildLanguageAlternates('/tool/hex-to-rgb-converter'),
     },
     openGraph: {
       title,
@@ -44,7 +45,7 @@ export default async function ToolHexToRgbConverterPage({
   const { lang } = await params;
   const t = getI18n(lang);
 
-  const url = `${projectUrl}/${lang}/tool/hex-to-rgb-converter/`;
+  const url = buildUrl('/tool/hex-to-rgb-converter', lang);
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -59,6 +60,13 @@ export default async function ToolHexToRgbConverterPage({
       applicationCategory: 'DeveloperTool',
       operatingSystem: 'All',
       url: url,
+      isAccessibleForFree: true,
+      offers: {
+        '@type': 'Offer',
+        price: '0',
+        priceCurrency: 'USD',
+      },
+      featureList: ['Convert HEX colors to RGB', 'Convert RGB colors to HEX', 'Adjust opacity for RGBA colors'],
     },
   };
 
@@ -75,6 +83,22 @@ export default async function ToolHexToRgbConverterPage({
         </Typography>
 
         <HexToRgbConverter labels={t.tools.hexToRgbConverter.form} numberFormat={t.numbers} />
+
+        <article className="max-w-3xl text-left flex flex-col gap-4">
+          <Typography variant="h2">How to use the HEX to RGB converter</Typography>
+          <Typography variant="body1">
+            Paste a HEX color value, such as #ffffff or #0f172a, and the tool calculates the matching red, green, and
+            blue channels. You can also edit RGB values to generate a HEX color for CSS, design systems, and UI
+            documentation.
+          </Typography>
+
+          <Typography variant="h2">Why this is useful</Typography>
+          <Typography variant="body1">
+            HEX is compact and common in CSS, while RGB and RGBA are easier to adjust when you need channel values or
+            opacity. Keeping both formats on the same page makes it faster to copy the exact value your implementation
+            needs.
+          </Typography>
+        </article>
       </section>
     </>
   );

--- a/src/app/[lang]/tool/rem-to-px-converter/page.tsx
+++ b/src/app/[lang]/tool/rem-to-px-converter/page.tsx
@@ -2,8 +2,8 @@ import React, { JSX } from 'react';
 import { getI18n } from '@/i18n/i18n';
 import { Typography } from '@mui/material';
 import RemToPxConverter from '@/components/tools/rem-to-pix-converter';
-import { projectUrl } from '@/conf';
 import { I18nLocaleInterface } from '@/i18n/i18n.interface';
+import { buildLanguageAlternates, buildUrl } from '@/shared/helpers/seo';
 
 export async function generateMetadata({ params }: { params: Promise<{ lang: string }> }) {
   const { lang } = await params;
@@ -11,13 +11,14 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
 
   const title = t.tools.remToPixConverter.title;
   const description = t.tools.remToPixConverter.description;
-  const url = `${projectUrl}/${lang}/tool/rem-to-px-converter/`;
+  const url = buildUrl('/tool/rem-to-px-converter', lang);
 
   return {
     title,
     description,
     alternates: {
       canonical: url,
+      languages: buildLanguageAlternates('/tool/rem-to-px-converter'),
     },
     openGraph: {
       title,
@@ -43,7 +44,7 @@ export default async function ToolRemToPixConverterPage({
   const { lang } = await params;
   const t = getI18n(lang);
 
-  const url = `${projectUrl}/${lang}/tool/rem-to-px-converter/`;
+  const url = buildUrl('/tool/rem-to-px-converter', lang);
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -58,6 +59,13 @@ export default async function ToolRemToPixConverterPage({
       applicationCategory: 'DeveloperTool',
       operatingSystem: 'All',
       url: url,
+      isAccessibleForFree: true,
+      offers: {
+        '@type': 'Offer',
+        price: '0',
+        priceCurrency: 'USD',
+      },
+      featureList: ['Convert REM to PX', 'Convert PX to REM', 'Customize the base font size'],
     },
   };
 
@@ -74,6 +82,20 @@ export default async function ToolRemToPixConverterPage({
         </Typography>
 
         <RemToPxConverter labels={t.tools.remToPixConverter.form} numberFormat={t.numbers} />
+
+        <article className="max-w-3xl text-left flex flex-col gap-4">
+          <Typography variant="h2">How to convert REM to PX</Typography>
+          <Typography variant="body1">
+            Use the formula: pixels = rem × base font size. For example, 1.5rem with a 16px base font size is 24px.
+            Change the base value when your project uses a custom root font size.
+          </Typography>
+
+          <Typography variant="h2">When to use this tool</Typography>
+          <Typography variant="body1">
+            REM units are useful for scalable typography and spacing, while pixels are often used in design specs. This
+            converter helps developers translate design values into accessible CSS units quickly.
+          </Typography>
+        </article>
       </section>
     </>
   );

--- a/src/shared/helpers/seo.ts
+++ b/src/shared/helpers/seo.ts
@@ -1,0 +1,15 @@
+import { langList, projectUrl } from '@/conf';
+
+export const buildUrl = (path: string, lang?: string): string => {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const localizedPath = lang ? `/${lang}${normalizedPath}` : normalizedPath;
+
+  return `${projectUrl}${localizedPath.endsWith('/') ? localizedPath : `${localizedPath}/`}`;
+};
+
+export const buildLanguageAlternates = (path: string): Record<string, string> =>
+  langList.reduce<Record<string, string>>((alternates, lang) => {
+    alternates[lang] = buildUrl(path, lang);
+
+    return alternates;
+  }, {});


### PR DESCRIPTION
### Motivation
- Centralize URL and language-alternate construction and improve page SEO metadata and structured data across pages.
- Surface the skills list on the resume page instead of keeping it hidden for better UX and semantic markup.
- Replace ad-hoc URL construction with a shared helper to ensure consistent canonical and alternate links.
- Provide richer JSON-LD and descriptive content for developer tool pages to improve discoverability.

### Description
- Added `src/shared/helpers/seo.ts` implementing `buildUrl` and `buildLanguageAlternates` for building canonical URLs and language alternates. 
- Updated `src/app/[lang]/resume/page.tsx` to export `generateMetadata`, use `Metadata` types, include `jsonLd` script, make the skills list visible by replacing the hidden section with a mapped `resumeSkills` array, and use `buildUrl`. 
- Updated tool pages `src/app/[lang]/tool/hex-to-rgb-converter/page.tsx` and `src/app/[lang]/tool/rem-to-px-converter/page.tsx` to use `buildUrl` and `buildLanguageAlternates`, enrich their JSON-LD with `isAccessibleForFree`, `offers`, and `featureList`, and add explanatory article content describing usage and benefits. 
- Replaced previous hardcoded URL construction with shared helpers and added Open Graph / Twitter metadata in page `generateMetadata` implementations. 

### Testing
- Ran TypeScript type check via `tsc --noEmit` and a project build via `next build`, and both commands completed successfully. 
- No unit tests were modified by this change and existing automated checks passed.

