### PR TITLE
Validate Yandex Metrika ID, add `NEXT_PUBLIC_YANDEX_METRIKA_ID` and documentation

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   NEXT_PUBLIC_BASE_PATH: /portfolio
-  NEXT_PUBLIC_YC_METRIC: ${{ vars.NEXT_PUBLIC_YC_METRIC }}
+  NEXT_PUBLIC_YANDEX_METRIKA_ID: ${{ vars.NEXT_PUBLIC_YANDEX_METRIKA_ID || vars.NEXT_PUBLIC_YC_METRIC }}
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ To run this project locally, follow these steps:
 
 4. Open your browser and go to http://localhost:3000 to view the project.
 
+### Yandex Metrica
+
+Yandex Metrica is injected during the Next.js static build when a numeric counter
+ID is available in a public environment variable:
+
+- Preferred variable: `NEXT_PUBLIC_YANDEX_METRIKA_ID`
+- Backward-compatible variable: `NEXT_PUBLIC_YC_METRIC`
+
+For GitHub Pages deployments, add `NEXT_PUBLIC_YANDEX_METRIKA_ID` as a GitHub
+Actions variable in the `prod` environment used by the build job. The value
+must be only the numeric counter ID, not the full script snippet or a URL.
+
 ### Available Scripts
 
 Here are some useful commands you can use:

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -25,8 +25,8 @@ export default async function LangLayout({
   params: Promise<{ lang: string; url: URL }>;
 }>) {
   const { lang } = await params;
-  const metrikaId = process.env.NEXT_PUBLIC_YC_METRIC;
-  
+  const metrikaId = process.env.NEXT_PUBLIC_YANDEX_METRIKA_ID ?? process.env.NEXT_PUBLIC_YC_METRIC;
+
   return (
     <html lang={lang}>
       <body className={`${ubuntuMono.className} bg-background`}>

--- a/src/components/analytics/yandex-metrika.component.tsx
+++ b/src/components/analytics/yandex-metrika.component.tsx
@@ -1,13 +1,19 @@
-'use client'
+'use client';
 
-import Script from 'next/script'
-import React from 'react'
+import Script from 'next/script';
+import React from 'react';
 
 interface YandexMetrikaProps {
-  id: string
+  id: string;
 }
 
 export const YandexMetrika: React.FC<YandexMetrikaProps> = ({ id }) => {
+  const counterId = id.trim();
+
+  if (!/^\d+$/.test(counterId)) {
+    return null;
+  }
+
   return (
     <>
       <Script
@@ -20,21 +26,21 @@ export const YandexMetrika: React.FC<YandexMetrikaProps> = ({ id }) => {
               m[i].l=1*new Date();
               for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
               k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
-            })(window, document,'script','https://mc.yandex.ru/metrika/tag.js?id=` + id + `', 'ym');
+            })(window, document,'script','https://mc.yandex.ru/metrika/tag.js?id=${counterId}', 'ym');
 
-            ym(` + id + `, 'init', {ssr:true, webvisor:true, clickmap:true, ecommerce:"dataLayer", accurateTrackBounce:true, trackLinks:true});
+            ym(${counterId}, 'init', {ssr:true, webvisor:true, clickmap:true, ecommerce:"dataLayer", accurateTrackBounce:true, trackLinks:true});
           `,
         }}
       />
       <noscript>
         <div>
           <img
-            src={`https://mc.yandex.ru/watch/${id}`}
+            src={`https://mc.yandex.ru/watch/${counterId}`}
             style={{ position: 'absolute', left: '-9999px' }}
             alt=""
           />
         </div>
       </noscript>
     </>
-  )
-}
+  );
+};


### PR DESCRIPTION
### Motivation

- Prevent injecting an incorrect value (full snippet/URL) instead of the numeric Yandex Metrika counter ID. 
- Provide a clearer public environment variable name and preserve backward compatibility with the existing one. 
- Make it explicit how to supply the counter ID during static `next build` (GitHub Actions/GitHub Pages) so the tag appears in the generated site.

### Description

- Add `trim()` and a numeric-only check in `YandexMetrika` so the component returns `null` when the provided ID is not a pure number and uses a local `counterId` for injection. 
- Use the validated `counterId` when injecting the tag script URL and when rendering the `<noscript>` watch image in `src/components/analytics/yandex-metrika.component.tsx`. 
- Prefer `NEXT_PUBLIC_YANDEX_METRIKA_ID` with a fallback to `NEXT_PUBLIC_YC_METRIC` in `src/app/[lang]/layout.tsx` so the build-time variable can be supplied more clearly. 
- Update the GitHub Actions deploy workflow to expose `NEXT_PUBLIC_YANDEX_METRIKA_ID` (falling back to the old var) and add README instructions describing the required numeric ID and where to set it in GitHub Actions.

### Testing

- Ran `npx prettier --check src/components/analytics/yandex-metrika.component.tsx src/app/[lang]/layout.tsx README.md .github/workflows/github-pages-deploy.yml`, which passed after formatting. 
- Ran `git diff --check` which reported no problems. 
- Ran `npm run build` in this environment which failed due to Next.js being unable to fetch Google Fonts during the build (network/font fetch issue) and not because of the Yandex Metrika changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4994bda590832788d26038f0577026)